### PR TITLE
pre-commit 追加

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/zsh
+
+# ステージングされた .c ファイルを取得
+changed_file=$(git diff --name-only --cached | grep '\.c$')
+
+# フォーマットを適用
+for file in ${changed_file};
+do
+    c_formatter_42 ${file}
+done
+
+# フォーマット後に変更を再ステージング
+git add ${changed_file}
+
+echo -e "\033[32mpre-commitが完了しました\033[0m"


### PR DESCRIPTION
`ln -s $(pwd)/scripts/pre-commit .git/hooks/` をローカルで実行すればコミット時にフォーマッターが走るようになる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automation during the commit process that automatically formats C source files before changes are finalized. This enhancement helps ensure consistent code style and streamlines the development workflow without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->