### PR TITLE
tabに対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/01 19:41:00 by yehara            #+#    #+#              #
-#    Updated: 2025/05/04 16:14:23 by ssoeno           ###   ########.fr        #
+#    Updated: 2025/05/06 15:24:04 by yehara           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -34,7 +34,8 @@ RAYTRACING_SRCS = raytracing.c \
 				  hit_cylinder.c
 # util
 UTIL_SRCS = error.c \
-			ft_xatof.c
+			ft_xatof.c \
+			split_space.c
 # init
 INIT_SRCS = init.c
 

--- a/include/util.h
+++ b/include/util.h
@@ -6,7 +6,7 @@
 /*   By: yehara <yehara@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/04 21:18:27 by yehara            #+#    #+#             */
-/*   Updated: 2025/04/14 18:23:58 by yehara           ###   ########.fr       */
+/*   Updated: 2025/05/06 15:23:30 by yehara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,5 +20,6 @@ int		free_double_array(char **array);
 double	ft_xatof(char *s);
 void	free_mlx(t_mlx *mlx);
 void	free_objects(t_list *objects);
+char	**split_space(char const *s);
 
 #endif

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -6,7 +6,7 @@
 /*   By: ssoeno <ssoeno@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/01 21:21:03 by yehara            #+#    #+#             */
-/*   Updated: 2025/05/01 17:50:36 by ssoeno           ###   ########.fr       */
+/*   Updated: 2025/05/06 15:24:49 by yehara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,9 @@ static int	parse_rt_line(char *line, t_scene *scene)
 	int		status;
 
 	status = 0;
-	elements = ft_xsplit(line, ' ');
+	elements = split_space(line);
+	if (elements == NULL)
+		return (EXIT_FAILURE);
 	if (ft_strncmp(elements[0], "A", 1) == 0)
 		status = parse_ambient(elements + 1, &scene->ambient);
 	else if (ft_strncmp(elements[0], "C", 1) == 0)

--- a/src/util/split_space.c
+++ b/src/util/split_space.c
@@ -51,7 +51,7 @@ static size_t	word_len(char const *s)
 static void	*allocate_buf(char **buf, int len, int i)
 {
 	buf[i] = (char *)malloc((len + 1) * sizeof(char));
-	if (buf == NULL)
+	if (buf[i] == NULL)
 	{
 		i--;
 		while (0 <= i)
@@ -94,6 +94,7 @@ char	**split_space(char const *s)
 {
 	size_t	words;
 	char	**buf;
+	char	**result;
 
 	words = 0;
 	if (s == NULL)
@@ -102,11 +103,11 @@ char	**split_space(char const *s)
 	buf = (char **)malloc((words + 1) * sizeof(char *));
 	if (buf == NULL)
 		return (NULL);
-	buf = split_string(buf, s);
-	if (buf == NULL)
+	result = split_string(buf, s);
+	if (result == NULL)
 	{
 		free(buf);
 		return (NULL);
 	}
-	return (buf);
+	return (result);
 }

--- a/src/util/split_space.c
+++ b/src/util/split_space.c
@@ -1,0 +1,112 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_xsplit.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yehara <yehara@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/04 21:27:43 by yehara            #+#    #+#             */
+/*   Updated: 2025/05/06 15:23:33 by yehara           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <libft.h>
+
+static size_t	word_count(char const *s)
+{
+	size_t	count;
+	int		in_word;
+
+	count = 0;
+	in_word = 0;
+	while (*s)
+	{
+		if (!ft_isspace(*s) && !in_word)
+		{
+			in_word = 1;
+			count++;
+		}
+		else if (ft_isspace(*s))
+		{
+			in_word = 0;
+		}
+		s++;
+	}
+	return (count);
+}
+
+static size_t	word_len(char const *s)
+{
+	size_t	len;
+
+	len = 0;
+	while (*s && !ft_isspace(*s))
+	{
+		len++;
+		s++;
+	}
+	return (len);
+}
+
+static void	*allocate_buf(char **buf, int len, int i)
+{
+	buf[i] = (char *)malloc((len + 1) * sizeof(char));
+	if (buf == NULL)
+	{
+		i--;
+		while (0 <= i)
+			free(buf[i--]);
+		return (NULL);
+	}
+	return (buf[i]);
+}
+
+static char	**split_string(char **buf, char const *s)
+{
+	int	word_length;
+	int	i;
+	int	j;
+
+	i = 0;
+	j = 0;
+	while (*s)
+	{
+		while (ft_isspace(*s))
+			s++;
+		if (*(s) == '\0')
+			break ;
+		word_length = word_len(s);
+		if (allocate_buf(buf, word_length, i) == NULL)
+			return (NULL);
+		while (j < word_length)
+		{
+			buf[i][j++] = *s++;
+		}
+		buf[i][j] = '\0';
+		j = 0;
+		i++;
+	}
+	buf[i] = NULL;
+	return (buf);
+}
+
+char	**split_space(char const *s)
+{
+	size_t	words;
+	char	**buf;
+
+	words = 0;
+	if (s == NULL)
+		return (NULL);
+	words = word_count(s);
+	buf = (char **)malloc((words + 1) * sizeof(char *));
+	if (buf == NULL)
+		return (NULL);
+	buf = split_string(buf, s);
+	if (buf == NULL)
+	{
+		free(buf);
+		return (NULL);
+	}
+	return (buf);
+}


### PR DESCRIPTION
要素を分割するとき、空白で split していたが tab に対応できないため、要素分割用の関数を追加
空行が入ったパターンも試したが正常に実行できた

```
25-05-06 15:29:19(c5r4s5.42tokyo.jp): ~/Documents/miniRT (fix/tab_split *%=)
yehara % ./miniRT original.rt
25-05-06 15:29:25(c5r4s5.42tokyo.jp): ~/Documents/miniRT (fix/tab_split *%=)
yehara % ./miniRT a.rt
25-05-06 15:29:28(c5r4s5.42tokyo.jp): ~/Documents/miniRT (fix/tab_split *%=)
```

試したテストケース　
original.rt
```
A 0.2	255,255,255
C	50,40,-100	0,0,1	45
L	0,50,0	0.7	255,255,255
sp	0,20,0	 20	255,0,0
pl	0,0,0	0,1,0	255,0,225
//sp 0,-20,0 20 255,255,0
//cy 0,0,0 0,1,0 14.2 100 255,0,0
//cy 0,0,0 1,0,0 14.2 100 255,0,0
```

a.rt
```
A 0.2 255,255,255
C 0,0,10 0,0,-1 60
L 100,100,100 0.8 255,255,255

sp 0,0,0 5 0,255,0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility function to split strings by whitespace, improving string processing capabilities.
- **Bug Fixes**
  - Added error handling to prevent processing when splitting a line fails during parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->